### PR TITLE
add firefox support

### DIFF
--- a/addon/components/search-flow.js
+++ b/addon/components/search-flow.js
@@ -139,7 +139,7 @@ export default Ember.Component.extend({
     return !this.get('filters').isAny('isFocused');
   }),
   actions: {
-    newFilter() {
+    newFilter(event) {
       if (event.which === 13) { // Enter key
         // Must prevent the filter from auto selecting an option
         this.set('didHitEnter', true);

--- a/addon/components/search-flow/input-dropdown.js
+++ b/addon/components/search-flow/input-dropdown.js
@@ -72,7 +72,7 @@ export default Ember.Component.extend({
     if (this.get('filter.parameter.sort')){
       options = options.sortBy('title');
     }
-    
+
     // Insert contains option into list
     if (this.get('filter.parameter.contains') && this.get('value') && options.length) {
       options.unshift(Ember.Object.create({ title: `Contains: ${this.get('value')}`, value: this.get('value'), isContains: true }));
@@ -114,7 +114,7 @@ export default Ember.Component.extend({
         this.get('newFilter')(activeOption.get('value'));
       }
       else {
-        
+
         this.set('filter.value', activeOption.get('value'));
         if (activeOption.get('isContains')) {
           this.set('filter.isContains', true);
@@ -135,7 +135,7 @@ export default Ember.Component.extend({
         this.send('selectOption', this.get('activeOption'));
       }
     },
-    inputKeyDown() {
+    inputKeyDown(_, event) {
       if (event.which === 38) { // Up
         event.preventDefault();
         let previousItem = this.get(`availableOptions.${this.get('activeOption.index') - 1}`);
@@ -158,7 +158,7 @@ export default Ember.Component.extend({
         this.blurInput();
       }
     },
-    inputKeyUp() {
+    inputKeyUp(_, event) {
       // Prevent the up or down key from moving the cursor when releasing the key
       if (event.which === 38 || event.which === 40) { // Up or Down
         event.preventDefault();
@@ -183,7 +183,7 @@ export default Ember.Component.extend({
 
       // Set the value to what the original filter value was
       this.set('filter.isFocused', false);
-      if (this.get('filter.isContains')) {  
+      if (this.get('filter.isContains')) {
         this.set('value', `Contains: ${this.get('filter.value')}`);
       }
       this.get('inputBlurred')(this.get('isParameterSelection'), this.get('filter'), this.get('shouldRemoveFilter'));

--- a/addon/templates/components/search-flow.hbs
+++ b/addon/templates/components/search-flow.hbs
@@ -2,7 +2,7 @@
 	{{#each filters as |filter|}}
 		<div class="search-flow__query">
 			<div class="search-flow__query-title">
-				{{filter.parameter.title}} : 
+				{{filter.parameter.title}} :
 			</div>
 			<div class="search-flow__query-value">
 				{{search-flow/input-dropdown
@@ -30,7 +30,7 @@
 		</div>
 	{{/if}}
 	{{#if availableParameters.length}}
-		<button class="search-flow_add{{unless canAddNewFilter ' search-flow_add-hidden'}}" {{action 'newFilter'}}>
+		<button class="search-flow_add{{unless canAddNewFilter ' search-flow_add-hidden'}}" onclick={{action 'newFilter'}}>
 			<svg class="add-icon" width="18px" height="18px" viewBox="608 440 44 44" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 				<defs></defs>
 				<path d="M627,476.001 C617.611,476.001 610,468.389 610,459 C610,449.611 617.611,442 627,442 C636.389,442 644,449.611 644,459 C644,468.389 636.389,476.001 627,476.001 Z M651.707,482.293 L641.108,471.694 C644.14,468.328 646,463.887 646,459 C646,448.507 637.494,440 627,440 C616.507,440 608,448.507 608,459 C608,469.494 616.507,478 627,478 C631.887,478 636.328,476.14 639.694,473.108 L650.293,483.707 C650.474,483.889 650.724,484 651,484 C651.553,484 652,483.553 652,483 C652,482.725 651.889,482.475 651.707,482.293 Z M636,458 L628,458 L628,450 C628,449.448 627.553,449 627,449 C626.447,449 626,449.448 626,450 L626,458 L618,458 C617.447,458 617,458.448 617,459 C617,459.553 617.447,460 618,460 L626,460 L626,468 C626,468.553 626.447,469 627,469 C627.553,469 628,468.553 628,468 L628,460 L636,460 C636.553,460 637,459.553 637,459 C637,458.448 636.553,458 636,458 L636,458 Z" id="add-search-icon" stroke="none" fill="#3B71AA" fill-rule="evenodd"></path>


### PR DESCRIPTION
**Problem:** in the [search flow](https://github.com/alechirsch/ember-search-flow/blob/master/addon/components/search-flow.js#L143) component you are using global window `event` property, which returns the Event which is currently being handled by the site's code. 

According to the [window event browser support](https://developer.mozilla.org/en-US/docs/Web/API/Window/event#Browser_Compatibility#Browser_Compatibility) it's being supported in all browsers and firefox since version 63.

According to the [ember action events doc](https://guides.emberjs.com/release/components/handling-events/#toc_sending-actions) event will be passed to the action, only when assigning the action to an inline handler.

So basically this PR removes usage of the `window.event` and replaces it with the event argument itself.

**P.S.** Tested on the Firefox#62 and Chrome#69

**P.P.S** Couldn't run tests because of [this error.](https://monosnap.com/direct/xRilLfZJk2HaK0ALlc3aRiutahDpoy)